### PR TITLE
Support authentication database (authSource)

### DIFF
--- a/etc/emq_auth_mongo.conf
+++ b/etc/emq_auth_mongo.conf
@@ -34,6 +34,12 @@ auth.mongo.pool = 8
 ## Value: String
 ## auth.mongo.password =
 
+## MongoDB AuthSource
+##
+## Value: String
+## Default: mqtt
+## auth.mongo.auth_source = admin
+
 ## MongoDB database
 ##
 ## Value: String

--- a/priv/emq_auth_mongo.schema
+++ b/priv/emq_auth_mongo.schema
@@ -36,6 +36,11 @@
   {datatype, string}
 ]}.
 
+{mapping, "auth.mongo.auth_source", "emq_auth_mongo.server", [
+  {default, "mqtt"},
+  {datatype, string}
+]}.
+
 {mapping, "auth.mongo.ssl", "emq_auth_mongo.server", [
   {default, false},
   {datatype, {enum, [true, false]}}
@@ -75,6 +80,7 @@
   Login = cuttlefish:conf_get("auth.mongo.login", Conf),
   Passwd = cuttlefish:conf_get("auth.mongo.password", Conf),
   DB = cuttlefish:conf_get("auth.mongo.database", Conf),
+  AuthSrc = cuttlefish:conf_get("auth.mongo.auth_source", Conf),
   R = cuttlefish:conf_get("auth.mongo.w_mode", Conf),
   W = cuttlefish:conf_get("auth.mongo.r_mode", Conf),
   Login0 = case Login =:= [] of
@@ -105,7 +111,8 @@
     false ->
       []
   end,
-  WorkerOptions = [{database, list_to_binary(DB)}] ++ Login0 ++ Passwd0 ++ W0 ++ R0 ++ Ssl,
+  WorkerOptions = [{database, list_to_binary(DB)}, {auth_source, list_to_binary(AuthSrc)}]
+                    ++ Login0 ++ Passwd0 ++ W0 ++ R0 ++ Ssl,
 
   Vars = cuttlefish_variable:fuzzy_matches(["auth", "mongo", "topology", "$name"], Conf),
   Options = lists:map(fun({_, Name}) ->

--- a/src/emq_auth_mongo_config.erl
+++ b/src/emq_auth_mongo_config.erl
@@ -36,7 +36,7 @@ unregister() ->
 %% Get ENV Register formatter
 %%--------------------------------------------------------------------
 register_formatter() ->
-    [clique:register_formatter(cuttlefish_variable:tokenize(Key), 
+    [clique:register_formatter(cuttlefish_variable:tokenize(Key),
      fun formatter_callback/2) || Key <- keys()].
 
 formatter_callback([_, _, "server"], Params) ->
@@ -45,10 +45,12 @@ formatter_callback([_, _, "pool"], Params) ->
     proplists:get_value(pool_size, Params);
 formatter_callback([_, _, "database"], Params) ->
     proplists:get_value(database, proplists:get_value(worker_options, Params));
+formatter_callback([_, _, "auth_source"], Params) ->
+    proplists:get_value(auth_source, proplists:get_value(worker_options, Params));
 formatter_callback([_, _, "login"], Params) ->
     proplists:get_value(login, proplists:get_value(worker_options, Params));
 formatter_callback([_, _, "password"], Params) ->
-    proplists:get_value(password, proplists:get_value(worker_options, Params)); 
+    proplists:get_value(password, proplists:get_value(worker_options, Params));
 formatter_callback([_, _, Key], Params) ->
     proplists:get_value(list_to_atom(Key), Params);
 formatter_callback([_, _, _, "password_hash"], Params) ->
@@ -86,6 +88,12 @@ config_callback([_, _, "database"], Value) ->
     {ok, Env} = application:get_env(?APP, server),
     Env1 = proplists:get_value(worker_options, Env),
     Env2 = lists:keyreplace(database, 1, Env1, {database, list_to_binary(Value)}),
+    application:set_env(?APP, server, lists:keyreplace(worker_options, 1, Env, {worker_options, Env2})),
+    " successfully\n";
+config_callback([_, _, "auth_source"], Value) ->
+    {ok, Env} = application:get_env(?APP, server),
+    Env1 = proplists:get_value(worker_options, Env),
+    Env2 = lists:keyreplace(auth_source, 1, Env1, {auth_source, list_to_binary(Value)}),
     application:set_env(?APP, server, lists:keyreplace(worker_options, 1, Env, {worker_options, Env2})),
     " successfully\n";
 config_callback([_, _, "login"], Value) ->
@@ -145,6 +153,7 @@ keys() ->
      "auth.mongo.login",
      "auth.mongo.password",
      "auth.mongo.database",
+     "auth.mongo.auth_source",
      "auth.mongo.auth_query.collection",
      "auth.mongo.auth_query.password_field",
      "auth.mongo.auth_query.password_hash",
@@ -166,9 +175,9 @@ parse_password_hash(Value) ->
     case string:tokens(Value, ",") of
           [Hash]           -> list_to_atom(Hash);
           [Prefix, Suffix] -> {list_to_atom(Prefix), list_to_atom(Suffix)};
-          [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash), 
-                                                list_to_atom(MacFun), 
-                                                list_to_integer(Iterations), 
+          [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash),
+                                                list_to_atom(MacFun),
+                                                list_to_integer(Iterations),
                                                 list_to_integer(Dklen)};
           _                -> plain
     end.


### PR DESCRIPTION
Support the `authSource` option in auth-mongo:
https://github.com/emqtt/mongodb-erlang/pull/4

Use `mqtt` as the default authSource for backward compatibility:
```
## MongoDB AuthSource
##
## Value: String
## Default: mqtt
## auth.mongo.auth_source = admin
```
