### PR TITLE
support both clientid and username in query

### DIFF
--- a/etc/emqx_auth_mongo.conf
+++ b/etc/emqx_auth_mongo.conf
@@ -129,5 +129,7 @@ auth.mongo.acl_query = on
 
 auth.mongo.acl_query.collection = mqtt_acl
 
-#auth.mongo.acl_query.selector = username=%u,clientid=%c
+#auth.mongo.acl_query.selector.1 = username=%u,clientid=%c
+#auth.mongo.acl_query.selector.2 = username=$all
+#auth.mongo.acl_query.selector.3 = clientid=$all
 auth.mongo.acl_query.selector = username=%u

--- a/etc/emqx_auth_mongo.conf
+++ b/etc/emqx_auth_mongo.conf
@@ -111,6 +111,7 @@ auth.mongo.auth_query.password_hash = sha256
 ## macfun: md4, md5, ripemd160, sha, sha224, sha256, sha384, sha512
 ## auth.mongo.auth_query.password_hash = pbkdf2,sha256,1000,20
 
+#auth.mongo.auth_query.selector = username=%u, clientid=%c
 auth.mongo.auth_query.selector = username=%u
 
 ## Enable superuser query.
@@ -120,6 +121,7 @@ auth.mongo.super_query.collection = mqtt_user
 
 auth.mongo.super_query.super_field = is_superuser
 
+#auth.mongo.super_query.selector = username=%u, clientid=%c
 auth.mongo.super_query.selector = username=%u
 
 ## Enable ACL query.
@@ -127,4 +129,5 @@ auth.mongo.acl_query = on
 
 auth.mongo.acl_query.collection = mqtt_acl
 
+#auth.mongo.acl_query.selector = username=%u,clientid=%c
 auth.mongo.acl_query.selector = username=%u

--- a/include/emqx_auth_mongo.hrl
+++ b/include/emqx_auth_mongo.hrl
@@ -1,6 +1,8 @@
 
 -define(APP, emqx_auth_mongo).
 
+-define(DEFAULT_SELECTORS, [{<<"username">>, <<"%u">>}]).
+
 -record(superquery, {collection = <<"mqtt_user">>,
                      field      = <<"is_superuser">>,
                      selector   = {<<"username">>, <<"%u">>}}).
@@ -12,4 +14,3 @@
 
 -record(aclquery, {collection = <<"mqtt_acl">>,
                    selector   = {<<"username">>, <<"%u">>}}).
-

--- a/priv/emqx_auth_mongo.schema
+++ b/priv/emqx_auth_mongo.schema
@@ -240,19 +240,37 @@ end}.
   {default, ""},
   {datatype, string}
 ]}.
+{mapping, "auth.mongo.acl_query.selector.$id", "emqx_auth_mongo.acl_query", [
+  {default, ""},
+  {datatype, string}
+]}.
 
 {translation, "emqx_auth_mongo.acl_query", fun(Conf) ->
   case cuttlefish:conf_get("auth.mongo.acl_query", Conf) of
     false -> cuttlefish:unset();
     true  -> Collection = cuttlefish:conf_get("auth.mongo.acl_query.collection", Conf),
-             SelectorStr = cuttlefish:conf_get("auth.mongo.acl_query.selector", Conf),
-             SelectorList =
-                 lists:map(fun(Selector) ->
-                         case string:tokens(Selector, "=") of
-                             [Field, Val] -> {list_to_binary(Field), list_to_binary(Val)};
-                             _ -> {<<"username">>, <<"%u">>}
-                         end
-                     end, string:tokens(SelectorStr, ", ")),
-             [{collection, Collection}, {selector, SelectorList}]
+             %SelectorStr = cuttlefish:conf_get("auth.mongo.acl_query.selector", Conf),
+             SelectorStrList =
+                lists:map(
+                    fun
+                        ({["auth","mongo","acl_query","selector"], ConfEntry}) ->
+                            ConfEntry;
+                        ({["auth","mongo","acl_query","selector", _], ConfEntry}) ->
+                            ConfEntry
+                    end,
+                    cuttlefish_variable:filter_by_prefix("auth.mongo.acl_query.selector", Conf)),
+            
+             SelectorListList =
+                 lists:map(
+                    fun(SelectorStr) ->
+                        lists:map(fun(Selector) ->
+                                case string:tokens(Selector, "=") of
+                                    [Field, Val] -> {list_to_binary(Field), list_to_binary(Val)};
+                                    _ -> {<<"username">>, <<"%u">>}
+                                end
+                            end, string:tokens(SelectorStr, ", "))
+                    end,
+                    SelectorStrList),
+             [{collection, Collection}, {selector, SelectorListList}]
   end
 end}.

--- a/priv/emqx_auth_mongo.schema
+++ b/priv/emqx_auth_mongo.schema
@@ -164,7 +164,15 @@ end}.
   Collection = cuttlefish:conf_get("auth.mongo.auth_query.collection", Conf),
   PasswordField = cuttlefish:conf_get("auth.mongo.auth_query.password_field", Conf),
   PasswordHash = cuttlefish:conf_get("auth.mongo.auth_query.password_hash", Conf),
-  Selector = cuttlefish:conf_get("auth.mongo.auth_query.selector", Conf),
+  SelectorStr = cuttlefish:conf_get("auth.mongo.auth_query.selector", Conf),
+  SelectorList =
+      lists:map(fun(Selector) ->
+              case string:tokens(Selector, "=") of
+                  [Field, Val] -> {list_to_binary(Field), list_to_binary(Val)};
+                  _ -> {<<"username">>, <<"%u">>}
+              end
+          end, string:tokens(SelectorStr, ", ")),
+
   PasswordFields = [list_to_binary(Field) || Field <- string:tokens(PasswordField, ",")],
   HashValue =
     case string:tokens(PasswordHash, ",") of
@@ -177,7 +185,7 @@ end}.
   {password_field, PasswordFields},
   %% Hash Algorithm: plain, md5, sha, sha256, pbkdf2?
   {password_hash, HashValue},
-  {selector, Selector}
+  {selector, SelectorList}
 ]
 end}.
 
@@ -206,8 +214,15 @@ end}.
     false -> cuttlefish:unset();
     true  -> Collection = cuttlefish:conf_get("auth.mongo.super_query.collection", Conf),
              SuperField = cuttlefish:conf_get("auth.mongo.super_query.super_field", Conf),
-             Selector = cuttlefish:conf_get("auth.mongo.super_query.selector", Conf),
-             [{collection, Collection}, {super_field, SuperField}, {selector, Selector}]
+             SelectorStr = cuttlefish:conf_get("auth.mongo.super_query.selector", Conf),
+             SelectorList =
+                 lists:map(fun(Selector) ->
+                         case string:tokens(Selector, "=") of
+                             [Field, Val] -> {list_to_binary(Field), list_to_binary(Val)};
+                             _ -> {<<"username">>, <<"%u">>}
+                         end
+                     end, string:tokens(SelectorStr, ", ")),
+             [{collection, Collection}, {super_field, SuperField}, {selector, SelectorList}]
   end
 end}.
 
@@ -230,7 +245,14 @@ end}.
   case cuttlefish:conf_get("auth.mongo.acl_query", Conf) of
     false -> cuttlefish:unset();
     true  -> Collection = cuttlefish:conf_get("auth.mongo.acl_query.collection", Conf),
-             Selector = cuttlefish:conf_get("auth.mongo.acl_query.selector", Conf),
-             [{collection, Collection}, {selector, Selector}]
+             SelectorStr = cuttlefish:conf_get("auth.mongo.acl_query.selector", Conf),
+             SelectorList =
+                 lists:map(fun(Selector) ->
+                         case string:tokens(Selector, "=") of
+                             [Field, Val] -> {list_to_binary(Field), list_to_binary(Val)};
+                             _ -> {<<"username">>, <<"%u">>}
+                         end
+                     end, string:tokens(SelectorStr, ", ")),
+             [{collection, Collection}, {selector, SelectorList}]
   end
 end}.

--- a/src/emqx_acl_mongo.erl
+++ b/src/emqx_acl_mongo.erl
@@ -34,12 +34,16 @@ check_acl({#mqtt_client{username = <<$$, _/binary>>}, _PubSub, _Topic}, _State) 
     ignore;
 
 check_acl({Client, PubSub, Topic}, #state{aclquery = AclQuery}) ->
-    #aclquery{collection = Coll, selector = Selector} = AclQuery,
-    case emqx_auth_mongo:query(Coll, maps:from_list(emqx_auth_mongo:replvars(Selector, Client))) of
+    #aclquery{collection = Coll, selector = SelectorList} = AclQuery,
+    SelectorMapList =
+        lists:map(fun(Selector) ->
+            maps:from_list(emqx_auth_mongo:replvars(Selector, Client))
+        end, SelectorList),
+    case emqx_auth_mongo:query_multi(Coll, SelectorMapList) of
         undefined ->
             ignore;
-        Row ->
-            case match(Client, Topic, topics(PubSub, Row)) of
+        Rows ->
+            case match(Client, Topic, topics(PubSub, Rows)) of
                 matched -> allow;
                 nomatch -> deny
             end
@@ -53,11 +57,17 @@ match(Client, Topic, [TopicFilter|More]) ->
         false -> match(Client, Topic, More)
     end.
 
-topics(publish, Row) ->
-    lists:umerge(maps:get(<<"publish">>, Row, []), maps:get(<<"pubsub">>, Row, []));
+topics(publish, Rows) ->
+    lists:foldl(fun(Row, Acc) ->
+        Topics = maps:get(<<"publish">>, Row, []) ++ maps:get(<<"pubsub">>, Row, []),
+        lists:umerge(Acc, Topics)
+    end, [], Rows);
 
-topics(subscribe, Row) ->
-    lists:umerge(maps:get(<<"subscribe">>, Row, []), maps:get(<<"pubsub">>, Row, [])).
+topics(subscribe, Rows) ->
+    lists:foldl(fun(Row, Acc) ->
+        Topics = maps:get(<<"subscribe">>, Row, []) ++ maps:get(<<"pubsub">>, Row, []),
+        lists:umerge(Acc, Topics)
+    end, [], Rows).
 
 feedvar(#mqtt_client{client_id = ClientId, username = Username}, Str) ->
     lists:foldl(fun({Var, Val}, Acc) ->

--- a/src/emqx_acl_mongo.erl
+++ b/src/emqx_acl_mongo.erl
@@ -35,7 +35,7 @@ check_acl({#mqtt_client{username = <<$$, _/binary>>}, _PubSub, _Topic}, _State) 
 
 check_acl({Client, PubSub, Topic}, #state{aclquery = AclQuery}) ->
     #aclquery{collection = Coll, selector = Selector} = AclQuery,
-    case emqx_auth_mongo:query(Coll, emqx_auth_mongo:replvar(Selector, Client)) of
+    case emqx_auth_mongo:query(Coll, maps:from_list(emqx_auth_mongo:replvars(Selector, Client))) of
         undefined ->
             ignore;
         Row ->
@@ -74,4 +74,3 @@ reload_acl(_State) ->
 
 description() ->
     "ACL with MongoDB".
-

--- a/src/emqx_auth_mongo.erl
+++ b/src/emqx_auth_mongo.erl
@@ -26,7 +26,7 @@
 
 -behaviour(ecpool_worker).
 
--export([replvar/2, replvars/2, connect/1, query/2]).
+-export([replvar/2, replvars/2, connect/1, query/2, query_multi/2]).
 
 -record(state, {authquery, superquery}).
 
@@ -117,3 +117,8 @@ connect(Opts) ->
 
 query(Collection, Selector) ->
     ecpool:with_client(?APP, fun(Conn) -> mongo_api:find_one(Conn, Collection, Selector, #{}) end).
+
+query_multi(Collection, SelectorList) ->
+    lists:map(fun(Selector) ->
+        query(Collection, Selector)
+    end, SelectorList).

--- a/src/emqx_auth_mongo.erl
+++ b/src/emqx_auth_mongo.erl
@@ -26,10 +26,10 @@
 
 -behaviour(ecpool_worker).
 
--export([replvar/2, connect/1, query/2]).
+-export([replvar/2, replvars/2, connect/1, query/2]).
 
 -record(state, {authquery, superquery}).
- 
+
 -define(EMPTY(Username), (Username =:= undefined orelse Username =:= <<>>)).
 
 %%--------------------------------------------------------------------
@@ -45,7 +45,7 @@ check(#mqtt_client{username = Username}, Password, _State) when ?EMPTY(Username)
 check(Client, Password, #state{authquery = AuthQuery, superquery = SuperQuery}) ->
     #authquery{collection = Collection, field = Fields,
                hash = HashType, selector = Selector} = AuthQuery,
-    case query(Collection, replvar(Selector, Client)) of
+    case query(Collection, maps:from_list(replvars(Selector, Client))) of
         undefined -> ignore;
         UserMap ->
             Result = case [maps:get(Field, UserMap, undefined) || Field <- Fields] of
@@ -72,7 +72,7 @@ check_pass(PassHash, Salt, Password, {HashType, salt}) ->
     check_pass(PassHash, hash(HashType, <<Password/binary, Salt/binary>>)).
 
 check_pass(PassHash, PassHash) -> ok;
-check_pass(_, _)               -> {error, password_error}. 
+check_pass(_, _)               -> {error, password_error}.
 
 hash(Type, Password) -> emqx_auth_mod:passwd_hash(Type, Password).
 
@@ -86,11 +86,16 @@ description() -> "Authentication with MongoDB".
 is_superuser(undefined, _MqttClient) ->
     false;
 is_superuser(#superquery{collection = Coll, field = Field, selector = Selector}, Client) ->
-    Row = query(Coll, replvar(Selector, Client)),
+    Row = query(Coll, maps:from_list(replvars(Selector, Client))),
     case maps:get(Field, Row, false) of
         true   -> true;
         _False -> false
     end.
+
+replvars(VarList, MqttClient) ->
+    lists:map(fun(Var) ->
+            replvar(Var, MqttClient)
+        end, VarList).
 
 replvar({Field, <<"%u">>}, #mqtt_client{username = Username}) ->
     {Field, Username};
@@ -112,4 +117,3 @@ connect(Opts) ->
 
 query(Collection, Selector) ->
     ecpool:with_client(?APP, fun(Conn) -> mongo_api:find_one(Conn, Collection, Selector, #{}) end).
-

--- a/src/emqx_auth_mongo_app.erl
+++ b/src/emqx_auth_mongo_app.erl
@@ -64,26 +64,19 @@ with_env(Name, Fun) ->
         {ok, Config} -> Fun(r(Name, Config))
     end.
 
-r(super_query, undefined) -> 
+r(super_query, undefined) ->
     undefined;
 r(super_query, Config) ->
     #superquery{collection = list_to_binary(get_value(collection, Config, "mqtt_user")),
                 field      = list_to_binary(get_value(super_field, Config, "is_superuser")),
-                selector   = parse_selector(get_value(selector, Config, {"username", "%u"}))};
+                selector   = get_value(selector, Config, ?DEFAULT_SELECTORS)};
 
 r(auth_query, Config) ->
     #authquery{collection = list_to_binary(get_value(collection, Config, "mqtt_user")),
                field      = get_value(password_field, Config, [<<"password">>]),
                hash       = get_value(password_hash, Config, sha256),
-               selector   = parse_selector(get_value(selector, Config, {"username", "%u"}))};
+               selector   = get_value(selector, Config, ?DEFAULT_SELECTORS)};
 
 r(acl_query, Config) ->
     #aclquery{collection = list_to_binary(get_value(collection, Config, "mqtt_acl")),
-              selector   = parse_selector(get_value(selector, Config, {"username", "%u"}))}.
-
-parse_selector(Selector) ->
-    case string:tokens(Selector, "=") of
-        [Field, Val] -> {list_to_binary(Field), list_to_binary(Val)};
-        _ -> {<<"username">>, <<"%u">>}
-    end.
-
+              selector   = get_value(selector, Config, ?DEFAULT_SELECTORS)}.

--- a/src/emqx_auth_mongo_app.erl
+++ b/src/emqx_auth_mongo_app.erl
@@ -79,4 +79,4 @@ r(auth_query, Config) ->
 
 r(acl_query, Config) ->
     #aclquery{collection = list_to_binary(get_value(collection, Config, "mqtt_acl")),
-              selector   = get_value(selector, Config, ?DEFAULT_SELECTORS)}.
+              selector   = get_value(selector, Config, [?DEFAULT_SELECTORS])}.


### PR DESCRIPTION

Use like this:
`auth.mongo.super_query.selector = username=%u, clientid=%c`
